### PR TITLE
Travis CI: flake8 finds Python syntax errors, undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 python:
     - "3.6"
 install:
+    - pip install flake8
+    # fail the build if there are Python syntax errors or undefined names
+    - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
     - sudo apt-get update
     - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
     - bash miniconda.sh -b -p $HOME/miniconda

--- a/pivy/graphics/__init__.py
+++ b/pivy/graphics/__init__.py
@@ -151,10 +151,10 @@ class Arrow(Line):
         self.set_arrow_direction()
 
     def set_arrow_direction(self):
-        pts = np.array(self.points)
+        pts = self.points
         self.arrow_translate.translation = tuple(pts[-1])
         direction = pts[-1] - pts[-2]
-        direction /= np.linalg.norm(direction)
+        direction.normalize()
         _rot = coin.SbRotation()
         _rot.setValue(coin.SbVec3f(0, 1, 0), coin.SbVec3f(*direction))
         self.arrow_rot.rotation.setValue(_rot)


### PR DESCRIPTION
```
70    E999 SyntaxError: invalid syntax
61    F821 undefined name 'np'
1     F823 local variable 'TimeStampDefault' (defined in enclosing scope on line 200) referenced before assignment
132
```